### PR TITLE
feat: setup ESLint and Prettier strict mode (#41)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,17 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parserOptions": { "ecmaVersion": 2022, "sourceType": "module", "project": "./tsconfig.json" },
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "rules": {
-    "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "no-console": "warn"
+    "prettier/prettier": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "eqeqeq": ["error", "always"],
+    "curly": "error"
   },
-  "env": { "node": true, "browser": true }
+  "ignorePatterns": ["dist/", "node_modules/", "coverage/", "*.js"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+coverage/
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,18 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "examples": "ts-node examples/",
-    "lint": "eslint src --ext .ts"
+    "lint": "eslint src --ext .ts --max-warnings 0",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\""
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.0",
+    "prettier": "^3.2.0"
+  }
 }


### PR DESCRIPTION
Fixes #41\n\n## What changed\n- Added `.eslintrc.json` with `@typescript-eslint/recommended`, no-explicit-any, no-floating-promises, Prettier integration\n- Added `.prettierrc.json` (single quotes, 100 print width, trailing commas, LF)\n- Added lint, lint:fix, format, format:check npm scripts\n- Added required devDependencies