### PR TITLE
feat: add multi-sig support for SDK calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,42 @@ console.log('Escrow created:', escrow.id);
 
 See [examples/](./examples/) for more complete examples.
 
+### Multi-Sig Escrow (M-of-N)
+
+Collect signatures from multiple approvers before a release is broadcast:
+
+```typescript
+import { MultiSigEscrowClient } from '@trustflow/sdk';
+import { Networks } from '@stellar/stellar-sdk';
+
+const client = new MultiSigEscrowClient({
+  contractId: process.env.TRUSTFLOW_CONTRACT_ID!,
+  network: 'TESTNET',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  networkPassphrase: Networks.TESTNET,
+});
+
+// Register a 2-of-2 release operation
+const { data: { operationId } } = client.initMultiSigOperation({
+  escrowId: 'esc-42',
+  signers: [APPROVER_A, APPROVER_B],
+  threshold: 2,
+  operationType: 'release',
+  unsignedXdr: UNSIGNED_RELEASE_XDR,
+  networkPassphrase: Networks.TESTNET,
+});
+
+// Each approver submits their signed XDR independently
+client.addSignature({ operationId, signerAddress: APPROVER_A, signedXdr: SIGNED_XDR_A });
+client.addSignature({ operationId, signerAddress: APPROVER_B, signedXdr: SIGNED_XDR_B });
+
+// Broadcast once threshold is met
+const result = await client.submitWhenReady(operationId, 'https://horizon-testnet.stellar.org');
+console.log('Released! tx:', result.data?.txHash);
+```
+
+See [examples/multisig-escrow.ts](./examples/multisig-escrow.ts) for the full walkthrough.
+
 ---
 
 ## ✨ Features
@@ -54,6 +90,7 @@ See [examples/](./examples/) for more complete examples.
 ### Current Capabilities
 
 - **🔐 Escrow Management**: Create, fund, release, and monitor escrows
+- **✍️ Multi-Sig Escrows**: M-of-N signature collection for shared backend Escrows via `MultiSigEscrowClient`
 - **⚖️ Dispute Resolution**: Raise and track disputes with on-chain governance
 - **🔑 Wallet Integration**: Built-in support for Freighter and Albedo wallets
 - **📊 Event Monitoring**: Real-time escrow state change tracking
@@ -91,7 +128,7 @@ The SDK is under active development. Here's what's coming:
 - [ ] Auto-retry logic for RPC endpoints
 
 ### Planned Features
-- [ ] Multi-signature support for corporate escrows
+- [x] Multi-signature support for corporate escrows
 - [ ] IPFS storage helpers for file uploads
 - [ ] Pagination support for high-volume queries
 - [ ] Event parsing utilities for XDR decoding

--- a/examples/multisig-escrow.ts
+++ b/examples/multisig-escrow.ts
@@ -1,0 +1,63 @@
+/**
+ * Example: Collect M-of-N signatures for a shared backend Escrow release
+ *
+ * Two approvers (e.g. a platform and an arbitrator) must both sign before
+ * the release transaction is broadcast to Horizon.
+ */
+import { MultiSigEscrowClient } from '../src/escrow/multisig';
+import { Networks } from '@stellar/stellar-sdk';
+
+const APPROVER_A = 'GAPPROVER_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const APPROVER_B = 'GAPPROVER_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+async function main() {
+  const client = new MultiSigEscrowClient({
+    contractId: process.env.TRUSTFLOW_CONTRACT_ID!,
+    network: 'TESTNET',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  // Step 1 — register a 2-of-2 release operation for escrow "esc-42"
+  const init = client.initMultiSigOperation({
+    escrowId: 'esc-42',
+    signers: [APPROVER_A, APPROVER_B],
+    threshold: 2,
+    operationType: 'release',
+    unsignedXdr: process.env.UNSIGNED_RELEASE_XDR!,
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  if (!init.ok) throw new Error(init.error);
+  const { operationId } = init.data;
+  console.log('Operation created:', operationId);
+
+  // Step 2 — each approver signs the XDR independently and submits their envelope
+  client.addSignature({
+    operationId,
+    signerAddress: APPROVER_A,
+    signedXdr: process.env.SIGNED_XDR_A!,
+  });
+
+  const statusAfterA = client.getMultiSigStatus(operationId);
+  if (statusAfterA.ok) {
+    console.log(`Signatures: ${statusAfterA.data.signaturesCollected}/${statusAfterA.data.threshold}`);
+  }
+
+  client.addSignature({
+    operationId,
+    signerAddress: APPROVER_B,
+    signedXdr: process.env.SIGNED_XDR_B!,
+  });
+
+  // Step 3 — threshold met, broadcast the assembled transaction
+  const result = await client.submitWhenReady(
+    operationId,
+    'https://horizon-testnet.stellar.org',
+  );
+
+  if (!result.ok) throw new Error(result.error);
+  console.log('Escrow released! tx:', result.data.txHash);
+}
+
+main().catch(console.error);

--- a/src/auth/challenge.ts
+++ b/src/auth/challenge.ts
@@ -9,7 +9,7 @@ export async function requestChallenge(apiUrl: string, address: string): Promise
   if (!res.ok) {
     throw new Error('Failed to get challenge');
   }
-  const { challenge } = await res.json();
+  const { challenge } = (await res.json()) as { challenge: string };
   return { challenge, expiresAt: Date.now() + 60_000, address };
 }
 
@@ -26,6 +26,6 @@ export async function verifyAndGetToken(
   if (!res.ok) {
     throw new Error('Signature verification failed');
   }
-  const { token } = await res.json();
+  const { token } = (await res.json()) as { token: string };
   return token;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,13 @@ export type TrustFlowErrorCode =
   | 'SIGNING_ERROR'
   | 'INVALID_CONFIG'
   | 'NOT_CONNECTED'
-  | 'BALANCE_FETCH_ERROR';
+  | 'BALANCE_FETCH_ERROR'
+  | 'MULTISIG_ERROR'
+  | 'MULTISIG_THRESHOLD_NOT_MET'
+  | 'MULTISIG_ALREADY_SIGNED'
+  | 'MULTISIG_EXPIRED'
+  | 'MULTISIG_INVALID_SIGNER'
+  | 'MULTISIG_XDR_ERROR';
 
 export class TrustFlowError extends Error {
   readonly code: TrustFlowErrorCode;
@@ -31,5 +37,30 @@ export class TrustFlowError extends Error {
 
   static validation(field: string, message: string): TrustFlowError {
     return new TrustFlowError(`Validation failed for ${field}: ${message}`, 'VALIDATION_ERROR');
+  }
+
+  static multiSigThresholdNotMet(collected: number, required: number): TrustFlowError {
+    return new TrustFlowError(
+      `Multi-sig threshold not met: ${collected}/${required} signatures collected`,
+      'MULTISIG_THRESHOLD_NOT_MET',
+    );
+  }
+
+  static multiSigExpired(operationId: string): TrustFlowError {
+    return new TrustFlowError(
+      `Multi-sig operation ${operationId} has expired`,
+      'MULTISIG_EXPIRED',
+    );
+  }
+
+  static multiSigInvalidSigner(address: string): TrustFlowError {
+    return new TrustFlowError(
+      `${address} is not an authorised signer for this operation`,
+      'MULTISIG_INVALID_SIGNER',
+    );
+  }
+
+  static multiSigXdrError(detail: string): TrustFlowError {
+    return new TrustFlowError(`Multi-sig XDR error: ${detail}`, 'MULTISIG_XDR_ERROR');
   }
 }

--- a/src/escrow/client.ts
+++ b/src/escrow/client.ts
@@ -1,9 +1,13 @@
-import { ContractConfig, InvokeContractParams, ContractCallResult } from '../types/contract';
+import { ContractConfig } from '../types/contract';
 import { EscrowParams, EscrowState, SDKResult } from '../types/index';
 import { assertStellarAddress, xlmToStroops } from '../utils/validation';
 
 export class TrustFlowEscrowClient {
-  constructor(private config: ContractConfig) {}
+  protected readonly contractConfig: ContractConfig;
+
+  constructor(config: ContractConfig) {
+    this.contractConfig = config;
+  }
 
   async createEscrow(
     params: EscrowParams,
@@ -27,7 +31,7 @@ export class TrustFlowEscrowClient {
     return { ok: true, data: { txHash: `release-${escrowId}-${Date.now()}` } };
   }
 
-  async getEscrow(escrowId: string): Promise<SDKResult<EscrowState | null>> {
+  async getEscrow(_escrowId: string): Promise<SDKResult<EscrowState | null>> {
     return { ok: true, data: null }; // Fetch from contract storage
   }
 }

--- a/src/escrow/dispute.ts
+++ b/src/escrow/dispute.ts
@@ -16,7 +16,7 @@ export class DisputeClient {
       if (!res.ok) {
         return { ok: false, error: `HTTP ${res.status}` };
       }
-      const data = await res.json();
+      const data = (await res.json()) as { id: string };
       return { ok: true, data: { disputeId: data.id } };
     } catch (e) {
       return { ok: false, error: String(e) };

--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -2,3 +2,4 @@ export { TrustFlowEscrowClient } from './client';
 export { EscrowBuilder } from './builder';
 export { EscrowMonitor } from './monitor';
 export { DisputeClient } from './dispute';
+export { MultiSigEscrowClient } from './multisig';

--- a/src/escrow/multisig.ts
+++ b/src/escrow/multisig.ts
@@ -1,0 +1,379 @@
+import { Transaction, xdr } from '@stellar/stellar-sdk';
+import type { ContractConfig } from '../types/contract';
+import type {
+  InitMultiSigParams,
+  AddSignatureParams,
+  MultiSigOperation,
+  MultiSigStatus,
+  SignatureEntry,
+  InitMultiSigResult,
+  AddSignatureResult,
+  GetStatusResult,
+  SubmitMultiSigResult,
+  GetXdrResult,
+} from '../types/multisig';
+import { submitTransaction } from '../stellar/transaction';
+
+/**
+ * Client for collecting M-of-N signatures on shared backend Escrow operations.
+ *
+ * Flow:
+ *  1. Call `initMultiSigOperation` with the base unsigned XDR and signer list.
+ *  2. Each authorised signer calls `addSignature` with their signed XDR.
+ *  3. Poll `getMultiSigStatus` to check progress.
+ *  4. Once `isReady` is true, call `submitWhenReady` to broadcast the transaction.
+ */
+export class MultiSigEscrowClient {
+  /** In-memory store of pending multi-sig operations, keyed by operationId. */
+  private readonly operations = new Map<string, MultiSigOperation>();
+  private _opCounter = 0;
+
+  constructor(private readonly config: ContractConfig) {}
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Initialises a new multi-sig operation for an escrow action.
+   *
+   * @param params - Configuration including signers list, threshold, XDR and network passphrase
+   * @returns operationId used to reference this operation in subsequent calls
+   */
+  initMultiSigOperation(params: InitMultiSigParams): InitMultiSigResult {
+    const validation = this._validateInitParams(params);
+    if (!validation.ok) return validation;
+
+    const operationId = `msig-${params.escrowId}-${Date.now()}-${++this._opCounter}`;
+    const operation: MultiSigOperation = {
+      operationId,
+      escrowId: params.escrowId,
+      operationType: params.operationType,
+      unsignedXdr: params.unsignedXdr,
+      networkPassphrase: params.networkPassphrase,
+      collectedSignatures: [],
+      threshold: params.threshold,
+      signers: [...params.signers],
+      status: 'pending',
+      createdAt: Date.now(),
+      expiresAt: params.expiresAt,
+    };
+
+    this.operations.set(operationId, operation);
+    return { ok: true, data: { operationId } };
+  }
+
+  /**
+   * Adds a signer's contribution to a pending multi-sig operation.
+   * Extracts the `DecoratedSignature` from the provided XDR envelope and merges
+   * it into the accumulated transaction without duplicating existing signatures.
+   *
+   * @param params - operationId, signerAddress, and the signer's signed XDR
+   * @returns Updated status snapshot after the signature is recorded
+   */
+  addSignature(params: AddSignatureParams): AddSignatureResult {
+    const operation = this.operations.get(params.operationId);
+    if (!operation) {
+      return { ok: false, error: `Operation ${params.operationId} not found` };
+    }
+
+    if (operation.status === 'submitted') {
+      return { ok: false, error: 'Operation already submitted' };
+    }
+    if (operation.status === 'expired') {
+      return { ok: false, error: 'Operation has expired' };
+    }
+
+    if (this._isExpired(operation)) {
+      operation.status = 'expired';
+      return { ok: false, error: 'Operation has expired' };
+    }
+
+    if (!operation.signers.includes(params.signerAddress)) {
+      return {
+        ok: false,
+        error: `${params.signerAddress} is not an authorised signer for this operation`,
+      };
+    }
+
+    const alreadySigned = operation.collectedSignatures.some(
+      (s) => s.signerAddress === params.signerAddress,
+    );
+    if (alreadySigned) {
+      return { ok: false, error: `${params.signerAddress} has already signed this operation` };
+    }
+
+    const xdrValidation = this._validateSignedXdr(params.signedXdr, operation.networkPassphrase);
+    if (!xdrValidation.ok) return xdrValidation;
+
+    const entry: SignatureEntry = {
+      signerAddress: params.signerAddress,
+      signedXdr: params.signedXdr,
+      addedAt: Date.now(),
+    };
+    operation.collectedSignatures.push(entry);
+
+    if (operation.collectedSignatures.length >= operation.threshold) {
+      operation.status = 'ready';
+    }
+
+    return { ok: true, data: this._buildStatus(operation) };
+  }
+
+  /**
+   * Returns the current signature-collection status for an operation.
+   *
+   * @param operationId - ID returned by `initMultiSigOperation`
+   */
+  getMultiSigStatus(operationId: string): GetStatusResult {
+    const operation = this.operations.get(operationId);
+    if (!operation) {
+      return { ok: false, error: `Operation ${operationId} not found` };
+    }
+
+    if (this._isExpired(operation) && operation.status === 'pending') {
+      operation.status = 'expired';
+    }
+
+    return { ok: true, data: this._buildStatus(operation) };
+  }
+
+  /**
+   * Submits the assembled transaction to Horizon once the signature threshold is met.
+   * All collected `DecoratedSignature` entries are merged into a single XDR envelope
+   * before broadcast.
+   *
+   * @param operationId - ID returned by `initMultiSigOperation`
+   * @param horizonUrl - Horizon server base URL (e.g. https://horizon-testnet.stellar.org)
+   * @returns Transaction hash on success
+   */
+  async submitWhenReady(operationId: string, horizonUrl: string): Promise<SubmitMultiSigResult> {
+    const operation = this.operations.get(operationId);
+    if (!operation) {
+      return { ok: false, error: `Operation ${operationId} not found` };
+    }
+
+    if (this._isExpired(operation)) {
+      operation.status = 'expired';
+      return { ok: false, error: 'Operation has expired' };
+    }
+
+    if (operation.collectedSignatures.length < operation.threshold) {
+      const needed = operation.threshold - operation.collectedSignatures.length;
+      return {
+        ok: false,
+        error: `Threshold not met: need ${needed} more signature(s) before submission`,
+      };
+    }
+
+    const assembledResult = this.getAssembledXdr(operationId);
+    if (!assembledResult.ok) return assembledResult;
+
+    try {
+      const submitted = await submitTransaction(assembledResult.data.xdr, horizonUrl);
+      operation.status = 'submitted';
+      return {
+        ok: true,
+        data: {
+          txHash: submitted.hash,
+          operationId,
+          escrowId: operation.escrowId,
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `Submission failed: ${String(e)}` };
+    }
+  }
+
+  /**
+   * Merges all collected signatures into the base XDR envelope and returns the
+   * assembled envelope ready for broadcast.
+   * Can be called at any point — useful for offline verification before submission.
+   *
+   * @param operationId - ID returned by `initMultiSigOperation`
+   * @returns Base-64 XDR string of the assembled transaction envelope
+   */
+  getAssembledXdr(operationId: string): GetXdrResult {
+    const operation = this.operations.get(operationId);
+    if (!operation) {
+      return { ok: false, error: `Operation ${operationId} not found` };
+    }
+
+    if (operation.collectedSignatures.length === 0) {
+      return { ok: false, error: 'No signatures collected yet' };
+    }
+
+    try {
+      const xdrResult = this._mergeSignatures(
+        operation.unsignedXdr,
+        operation.collectedSignatures.map((s) => s.signedXdr),
+      );
+      return { ok: true, data: { xdr: xdrResult } };
+    } catch (e) {
+      return { ok: false, error: `XDR assembly failed: ${String(e)}` };
+    }
+  }
+
+  /**
+   * Returns all operations associated with a given escrow, regardless of status.
+   *
+   * @param escrowId - Escrow identifier
+   */
+  listOperations(escrowId: string): MultiSigOperation[] {
+    return Array.from(this.operations.values()).filter((op) => op.escrowId === escrowId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _validateInitParams(params: InitMultiSigParams): InitMultiSigResult | { ok: true } {
+    if (!params.escrowId) {
+      return { ok: false, error: 'escrowId is required' };
+    }
+    if (!params.signers || params.signers.length === 0) {
+      return { ok: false, error: 'At least one signer is required' };
+    }
+    if (params.threshold < 1) {
+      return { ok: false, error: 'threshold must be at least 1' };
+    }
+    if (params.threshold > params.signers.length) {
+      return {
+        ok: false,
+        error: `threshold (${params.threshold}) cannot exceed the number of signers (${params.signers.length})`,
+      };
+    }
+    if (!params.unsignedXdr) {
+      return { ok: false, error: 'unsignedXdr is required' };
+    }
+    if (!params.networkPassphrase) {
+      return { ok: false, error: 'networkPassphrase is required' };
+    }
+    if (params.networkPassphrase !== this.config.networkPassphrase) {
+      return {
+        ok: false,
+        error: `networkPassphrase mismatch: expected "${this.config.networkPassphrase}"`,
+      };
+    }
+
+    const uniqueSigners = new Set(params.signers);
+    if (uniqueSigners.size !== params.signers.length) {
+      return { ok: false, error: 'Duplicate signer addresses are not allowed' };
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Validates that a provided XDR is a parseable Stellar transaction envelope.
+   * Returns ok:false with a descriptive error on any parse failure.
+   */
+  private _validateSignedXdr(
+    signedXdr: string,
+    networkPassphrase: string,
+  ): { ok: true } | { ok: false; error: string } {
+    try {
+      new Transaction(signedXdr, networkPassphrase);
+      return { ok: true };
+    } catch {
+      try {
+        // FeeBump transactions are also valid envelopes
+        xdr.TransactionEnvelope.fromXDR(signedXdr, 'base64');
+        return { ok: true };
+      } catch {
+        return { ok: false, error: 'signedXdr is not a valid Stellar transaction envelope' };
+      }
+    }
+  }
+
+  /**
+   * Merges `DecoratedSignature` entries from all `signedXdrs` into the base envelope.
+   * Deduplicates by signature hint to prevent double-counting the same signer.
+   */
+  private _mergeSignatures(baseXdr: string, signedXdrs: string[]): string {
+    const baseEnvelope = xdr.TransactionEnvelope.fromXDR(baseXdr, 'base64');
+
+    // Collect all unique decorated signatures from contributor envelopes
+    const seen = new Set<string>();
+    const merged: xdr.DecoratedSignature[] = [];
+
+    // Preserve any signatures already on the base envelope
+    const baseSignatures = this._extractSignatures(baseEnvelope);
+    for (const sig of baseSignatures) {
+      const key = `${sig.hint().toString('hex')}:${sig.signature().toString('hex')}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        merged.push(sig);
+      }
+    }
+
+    // Add new signatures from each contributor
+    for (const signedXdr of signedXdrs) {
+      const envelope = xdr.TransactionEnvelope.fromXDR(signedXdr, 'base64');
+      const sigs = this._extractSignatures(envelope);
+      for (const sig of sigs) {
+        const key = `${sig.hint().toString('hex')}:${sig.signature().toString('hex')}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          merged.push(sig);
+        }
+      }
+    }
+
+    // Write merged signatures back onto the base envelope
+    this._setSignatures(baseEnvelope, merged);
+    return baseEnvelope.toXDR('base64');
+  }
+
+  /** Extracts `DecoratedSignature[]` from any TransactionEnvelope variant. */
+  private _extractSignatures(envelope: xdr.TransactionEnvelope): xdr.DecoratedSignature[] {
+    const type = envelope.switch();
+    if (type === xdr.EnvelopeType.envelopeTypeTx()) {
+      return envelope.v1().signatures();
+    }
+    if (type === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
+      return envelope.feeBump().signatures();
+    }
+    // Legacy v0 envelope
+    return (envelope as any).v0?.().signatures?.() ?? [];
+  }
+
+  /** Replaces the signatures array on an envelope in-place. */
+  private _setSignatures(
+    envelope: xdr.TransactionEnvelope,
+    signatures: xdr.DecoratedSignature[],
+  ): void {
+    const type = envelope.switch();
+    if (type === xdr.EnvelopeType.envelopeTypeTx()) {
+      envelope.v1().signatures(signatures);
+    } else if (type === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
+      envelope.feeBump().signatures(signatures);
+    } else {
+      (envelope as any).v0?.().signatures?.(signatures);
+    }
+  }
+
+  private _isExpired(operation: MultiSigOperation): boolean {
+    return operation.expiresAt !== undefined && Date.now() > operation.expiresAt;
+  }
+
+  private _buildStatus(operation: MultiSigOperation): MultiSigStatus {
+    const signersSigned = operation.collectedSignatures.map((s) => s.signerAddress);
+    const signersRemaining = operation.signers.filter((s) => !signersSigned.includes(s));
+
+    return {
+      operationId: operation.operationId,
+      escrowId: operation.escrowId,
+      operationType: operation.operationType,
+      signaturesCollected: operation.collectedSignatures.length,
+      threshold: operation.threshold,
+      signersAuthorised: [...operation.signers],
+      signersSigned,
+      signersRemaining,
+      isReady: operation.collectedSignatures.length >= operation.threshold,
+      status: operation.status,
+      createdAt: operation.createdAt,
+      expiresAt: operation.expiresAt,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './types/contract';
 export * from './types/events';
+export * from './types/multisig';
 export * from './escrow';
 export * from './auth';
 export * from './stellar';

--- a/src/stellar/account.ts
+++ b/src/stellar/account.ts
@@ -17,8 +17,8 @@ export async function fetchAccountInfo(
     if (!res.ok) {
       return { address, balanceXLM: '0', sequenceNumber: '0', isActive: false };
     }
-    const data = await res.json();
-    const xlm = data.balances?.find((b: any) => b.asset_type === 'native');
+    const data = (await res.json()) as { balances: Array<{ asset_type: string; balance: string }>; sequence: string };
+    const xlm = data.balances?.find((b) => b.asset_type === 'native');
     return {
       address,
       balanceXLM: xlm?.balance ?? '0',

--- a/src/stellar/transaction.ts
+++ b/src/stellar/transaction.ts
@@ -19,9 +19,14 @@ export async function submitTransaction(xdr: string, horizonUrl: string): Promis
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: `tx=${encodeURIComponent(xdr)}`,
   });
-  const data = await res.json();
+  const data = (await res.json()) as {
+    hash: string;
+    successful: boolean;
+    ledger?: number;
+    extras?: { result_codes?: { transaction?: string } };
+  };
   if (!res.ok) {
-    throw new Error(data.extras?.result_codes?.transaction || 'Submission failed');
+    throw new Error(data.extras?.result_codes?.transaction ?? 'Submission failed');
   }
   return { hash: data.hash, successful: data.successful, ledger: data.ledger };
 }

--- a/src/types/multisig.ts
+++ b/src/types/multisig.ts
@@ -1,0 +1,107 @@
+import type { StellarAddress, EscrowId, TxHash, SDKResult } from './index';
+
+export type MultiSigOperationType = 'release' | 'cancel' | 'dispute';
+export type MultiSigOperationStatus = 'pending' | 'ready' | 'submitted' | 'expired';
+
+/**
+ * M-of-N multi-sig configuration for a shared backend escrow.
+ * `threshold` signers out of `signers.length` must approve before the operation proceeds.
+ */
+export interface MultiSigConfig {
+  escrowId: EscrowId;
+  /** M: number of signatures required to meet threshold */
+  threshold: number;
+  /** N: ordered list of authorised Stellar addresses */
+  signers: StellarAddress[];
+}
+
+/** A single collected signature entry for a multi-sig operation */
+export interface SignatureEntry {
+  /** Stellar address of the signer */
+  signerAddress: StellarAddress;
+  /**
+   * XDR envelope produced by this signer — the SDK merges signatures from
+   * all collected envelopes into a single submission-ready XDR.
+   */
+  signedXdr: string;
+  addedAt: number;
+}
+
+/** Internal state of one pending multi-sig operation */
+export interface MultiSigOperation {
+  operationId: string;
+  escrowId: EscrowId;
+  operationType: MultiSigOperationType;
+  /** The base (unsigned or partially-signed) XDR envelope */
+  unsignedXdr: string;
+  networkPassphrase: string;
+  collectedSignatures: SignatureEntry[];
+  /** M — signatures required before submission */
+  threshold: number;
+  /** N — full set of authorised signers */
+  signers: StellarAddress[];
+  status: MultiSigOperationStatus;
+  createdAt: number;
+  expiresAt?: number;
+}
+
+/** Parameters for initiating a new multi-sig operation */
+export interface InitMultiSigParams {
+  escrowId: EscrowId;
+  /** Ordered list of authorised signer addresses */
+  signers: StellarAddress[];
+  /** Number of signatures required (must be ≥ 1 and ≤ signers.length) */
+  threshold: number;
+  operationType: MultiSigOperationType;
+  /** Base transaction XDR to be signed by `threshold` of the listed signers */
+  unsignedXdr: string;
+  networkPassphrase: string;
+  /** Optional UNIX timestamp (ms) after which the operation is considered expired */
+  expiresAt?: number;
+}
+
+/** Parameters for contributing a signature to an existing operation */
+export interface AddSignatureParams {
+  operationId: string;
+  /** Address of the signer submitting this signature */
+  signerAddress: StellarAddress;
+  /**
+   * Fully signed XDR envelope from this signer.
+   * The SDK extracts the new `DecoratedSignature` and merges it into the
+   * accumulated envelope without duplicating previously collected signatures.
+   */
+  signedXdr: string;
+}
+
+/** Read-only snapshot of signature-collection progress */
+export interface MultiSigStatus {
+  operationId: string;
+  escrowId: EscrowId;
+  operationType: MultiSigOperationType;
+  signaturesCollected: number;
+  threshold: number;
+  /** Full authorised-signer list */
+  signersAuthorised: StellarAddress[];
+  /** Subset who have already signed */
+  signersSigned: StellarAddress[];
+  /** Subset who have not yet signed */
+  signersRemaining: StellarAddress[];
+  /** True when signaturesCollected >= threshold */
+  isReady: boolean;
+  status: MultiSigOperationStatus;
+  createdAt: number;
+  expiresAt?: number;
+}
+
+/** Result returned after successfully submitting a ready multi-sig transaction */
+export interface MultiSigSubmitResult {
+  txHash: TxHash;
+  operationId: string;
+  escrowId: EscrowId;
+}
+
+export type InitMultiSigResult = SDKResult<{ operationId: string }>;
+export type AddSignatureResult = SDKResult<MultiSigStatus>;
+export type GetStatusResult = SDKResult<MultiSigStatus>;
+export type SubmitMultiSigResult = SDKResult<MultiSigSubmitResult>;
+export type GetXdrResult = SDKResult<{ xdr: string }>;

--- a/tests/multisig.test.ts
+++ b/tests/multisig.test.ts
@@ -1,0 +1,501 @@
+import {
+  Keypair,
+  Transaction,
+  TransactionBuilder,
+  Account,
+  Networks,
+  Operation,
+  Asset,
+} from '@stellar/stellar-sdk';
+import { MultiSigEscrowClient } from '../src/escrow/multisig';
+import type { ContractConfig } from '../src/types/contract';
+
+// ---------------------------------------------------------------------------
+// Helpers — build real Stellar XDR payloads
+// ---------------------------------------------------------------------------
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const CONTRACT_CONFIG: ContractConfig = {
+  contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+  network: 'TESTNET',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  networkPassphrase: NETWORK_PASSPHRASE,
+};
+
+function makeKeyPair() {
+  return Keypair.random();
+}
+
+/** Builds a minimal unsigned Stellar transaction XDR (v1 envelope). */
+function buildUnsignedXdr(sourceKeypair: Keypair, destKeypair: Keypair): string {
+  const account = new Account(sourceKeypair.publicKey(), '100');
+  const tx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: destKeypair.publicKey(),
+        asset: Asset.native(),
+        amount: '1',
+      }),
+    )
+    .setTimeout(30)
+    .build();
+  return tx.toEnvelope().toXDR('base64');
+}
+
+/** Signs the given XDR with the provided keypair and returns the new XDR. */
+function signXdr(baseXdr: string, keypair: Keypair): string {
+  const tx = new Transaction(baseXdr, NETWORK_PASSPHRASE);
+  tx.sign(keypair);
+  return tx.toEnvelope().toXDR('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const KP_A = makeKeyPair();
+const KP_B = makeKeyPair();
+const KP_C = makeKeyPair();
+const KP_DEST = makeKeyPair();
+
+const BASE_XDR = buildUnsignedXdr(KP_A, KP_DEST);
+const SIGNED_A = signXdr(BASE_XDR, KP_A);
+const SIGNED_B = signXdr(BASE_XDR, KP_B);
+
+const ESCROW_ID = 'esc-test-001';
+
+// ---------------------------------------------------------------------------
+// Suites
+// ---------------------------------------------------------------------------
+
+describe('MultiSigEscrowClient', () => {
+  let client: MultiSigEscrowClient;
+
+  beforeEach(() => {
+    client = new MultiSigEscrowClient(CONTRACT_CONFIG);
+  });
+
+  // -------------------------------------------------------------------------
+  // initMultiSigOperation
+  // -------------------------------------------------------------------------
+  describe('initMultiSigOperation', () => {
+    it('returns an operationId for valid params', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.operationId).toMatch(/^msig-/);
+      }
+    });
+
+    it('supports 1-of-N threshold', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey(), KP_C.publicKey()],
+        threshold: 1,
+        operationType: 'cancel',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('fails when escrowId is missing', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: '',
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('escrowId');
+    });
+
+    it('fails when threshold exceeds signer count', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 3,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('threshold');
+    });
+
+    it('fails when threshold is zero', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 0,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('threshold');
+    });
+
+    it('fails when signers list is empty', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('signer');
+    });
+
+    it('fails when signers contain duplicates', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('Duplicate');
+    });
+
+    it('fails when unsignedXdr is missing', () => {
+      const result = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: '',
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('unsignedXdr');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addSignature
+  // -------------------------------------------------------------------------
+  describe('addSignature', () => {
+    let operationId: string;
+
+    beforeEach(() => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (init.ok) operationId = init.data.operationId;
+    });
+
+    it('accepts a valid signature from an authorised signer', () => {
+      const result = client.addSignature({
+        operationId,
+        signerAddress: KP_A.publicKey(),
+        signedXdr: SIGNED_A,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.signaturesCollected).toBe(1);
+        expect(result.data.signersSigned).toContain(KP_A.publicKey());
+        expect(result.data.signersRemaining).toContain(KP_B.publicKey());
+        expect(result.data.isReady).toBe(false);
+      }
+    });
+
+    it('marks operation ready when threshold is met', () => {
+      client.addSignature({ operationId, signerAddress: KP_A.publicKey(), signedXdr: SIGNED_A });
+      const result = client.addSignature({
+        operationId,
+        signerAddress: KP_B.publicKey(),
+        signedXdr: SIGNED_B,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.signaturesCollected).toBe(2);
+        expect(result.data.isReady).toBe(true);
+        expect(result.data.status).toBe('ready');
+      }
+    });
+
+    it('rejects a signer not in the authorised list', () => {
+      const result = client.addSignature({
+        operationId,
+        signerAddress: KP_C.publicKey(),
+        signedXdr: signXdr(BASE_XDR, KP_C),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('not an authorised signer');
+    });
+
+    it('rejects duplicate signatures from the same signer', () => {
+      client.addSignature({ operationId, signerAddress: KP_A.publicKey(), signedXdr: SIGNED_A });
+      const dup = client.addSignature({
+        operationId,
+        signerAddress: KP_A.publicKey(),
+        signedXdr: SIGNED_A,
+      });
+      expect(dup.ok).toBe(false);
+      if (!dup.ok) expect(dup.error).toContain('already signed');
+    });
+
+    it('rejects an invalid XDR payload', () => {
+      const result = client.addSignature({
+        operationId,
+        signerAddress: KP_A.publicKey(),
+        signedXdr: 'not-valid-xdr',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('valid Stellar transaction envelope');
+    });
+
+    it('returns error for unknown operationId', () => {
+      const result = client.addSignature({
+        operationId: 'does-not-exist',
+        signerAddress: KP_A.publicKey(),
+        signedXdr: SIGNED_A,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('not found');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getMultiSigStatus
+  // -------------------------------------------------------------------------
+  describe('getMultiSigStatus', () => {
+    it('returns correct initial status', () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'cancel',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const status = client.getMultiSigStatus(init.data.operationId);
+      expect(status.ok).toBe(true);
+      if (status.ok) {
+        expect(status.data.signaturesCollected).toBe(0);
+        expect(status.data.threshold).toBe(2);
+        expect(status.data.isReady).toBe(false);
+        expect(status.data.status).toBe('pending');
+        expect(status.data.signersAuthorised).toHaveLength(2);
+        expect(status.data.signersRemaining).toHaveLength(2);
+        expect(status.data.signersSigned).toHaveLength(0);
+      }
+    });
+
+    it('returns error for unknown operationId', () => {
+      const result = client.getMultiSigStatus('ghost-id');
+      expect(result.ok).toBe(false);
+    });
+
+    it('marks expired operations', () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+        expiresAt: Date.now() - 1000,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const status = client.getMultiSigStatus(init.data.operationId);
+      expect(status.ok).toBe(true);
+      if (status.ok) {
+        expect(status.data.status).toBe('expired');
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAssembledXdr
+  // -------------------------------------------------------------------------
+  describe('getAssembledXdr', () => {
+    it('produces a valid XDR with merged signatures', () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const opId = init.data.operationId;
+      client.addSignature({ operationId: opId, signerAddress: KP_A.publicKey(), signedXdr: SIGNED_A });
+      client.addSignature({ operationId: opId, signerAddress: KP_B.publicKey(), signedXdr: SIGNED_B });
+
+      const assembled = client.getAssembledXdr(opId);
+      expect(assembled.ok).toBe(true);
+      if (assembled.ok) {
+        // Must be parseable and contain both signatures
+        const tx = new Transaction(assembled.data.xdr, NETWORK_PASSPHRASE);
+        expect(tx.signatures).toHaveLength(2);
+      }
+    });
+
+    it('returns error when no signatures have been collected', () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const assembled = client.getAssembledXdr(init.data.operationId);
+      expect(assembled.ok).toBe(false);
+      if (!assembled.ok) expect(assembled.error).toContain('No signatures');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // submitWhenReady
+  // -------------------------------------------------------------------------
+  describe('submitWhenReady', () => {
+    it('returns threshold-not-met error when below threshold', async () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const opId = init.data.operationId;
+      client.addSignature({ operationId: opId, signerAddress: KP_A.publicKey(), signedXdr: SIGNED_A });
+
+      const result = await client.submitWhenReady(opId, 'https://horizon-testnet.stellar.org');
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('Threshold not met');
+    });
+
+    it('returns expired error for an expired operation', async () => {
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+        expiresAt: Date.now() - 1,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const result = await client.submitWhenReady(
+        init.data.operationId,
+        'https://horizon-testnet.stellar.org',
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('expired');
+    });
+
+    it('attempts submission when threshold is met (mocked fetch)', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ hash: 'abc123', successful: true, ledger: 42 }),
+      }) as jest.Mock;
+
+      const init = client.initMultiSigOperation({
+        escrowId: ESCROW_ID,
+        signers: [KP_A.publicKey(), KP_B.publicKey()],
+        threshold: 2,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      expect(init.ok).toBe(true);
+      if (!init.ok) return;
+
+      const opId = init.data.operationId;
+      client.addSignature({ operationId: opId, signerAddress: KP_A.publicKey(), signedXdr: SIGNED_A });
+      client.addSignature({ operationId: opId, signerAddress: KP_B.publicKey(), signedXdr: SIGNED_B });
+
+      const result = await client.submitWhenReady(opId, 'https://horizon-testnet.stellar.org');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.txHash).toBe('abc123');
+        expect(result.data.escrowId).toBe(ESCROW_ID);
+      }
+
+      (global.fetch as jest.Mock).mockRestore();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listOperations
+  // -------------------------------------------------------------------------
+  describe('listOperations', () => {
+    it('returns all operations for a given escrowId', () => {
+      client.initMultiSigOperation({
+        escrowId: 'esc-111',
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'release',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      client.initMultiSigOperation({
+        escrowId: 'esc-111',
+        signers: [KP_B.publicKey()],
+        threshold: 1,
+        operationType: 'cancel',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      client.initMultiSigOperation({
+        escrowId: 'esc-999',
+        signers: [KP_A.publicKey()],
+        threshold: 1,
+        operationType: 'dispute',
+        unsignedXdr: BASE_XDR,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+
+      const ops = client.listOperations('esc-111');
+      expect(ops).toHaveLength(2);
+      expect(ops.every((op) => op.escrowId === 'esc-111')).toBe(true);
+    });
+
+    it('returns empty array when no operations exist for escrowId', () => {
+      expect(client.listOperations('no-such-escrow')).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `MultiSigEscrowClient` — an M-of-N signature collection mechanism for shared backend Escrows
- Adds `src/types/multisig.ts` with full type definitions (`MultiSigConfig`, `MultiSigOperation`, `SignatureEntry`, `InitMultiSigParams`, `AddSignatureParams`, `MultiSigStatus`)
- Each authorised signer contributes an independently signed XDR envelope; the SDK extracts `DecoratedSignature` entries, deduplicates, and merges them into a single submission-ready envelope
- Adds six new `TrustFlowErrorCode` variants and static factory helpers for multi-sig specific errors
- Exports `MultiSigEscrowClient` from the top-level package index (ESM + CJS + `.d.ts` all verified)
- 24 Jest tests covering: init validation, XDR payload merging, threshold gating, duplicate/invalid signer rejection, expiry logic, and mocked submission
- Fixes pre-existing TypeScript strict-mode errors in `stellar/transaction.ts`, `stellar/account.ts`, `auth/challenge.ts`, `escrow/client.ts`, and `escrow/dispute.ts` that were blocking `npm run build`

## Test plan

- [x] `npx jest tests/multisig.test.ts` — 24/24 passing
- [x] `npm run build` — ESM, CJS, and DTS all succeed
- [x] No regressions in the 10 previously-passing test suites

Closes #48