### PR TITLE
feat(sdk): add Transaction Assembly, Simulation, Fee-Bump & Retry Pip…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ See [examples/multisig-escrow.ts](./examples/multisig-escrow.ts) for the full wa
 ### Current Capabilities
 
 - **🔐 Escrow Management**: Create, fund, release, and monitor escrows
+- **🚀 Transaction Pipeline**: Assemble, simulate, auto-adjust resource fees, fee-bump, and retry Soroban transactions via `TransactionPipeline`, with typed `PipelineResult<T>` errors
 - **✍️ Multi-Sig Escrows**: M-of-N signature collection for shared backend Escrows via `MultiSigEscrowClient`
 - **⚖️ Dispute Resolution**: Raise and track disputes with on-chain governance
 - **🔁 Backend API Auto-Retries**: Resilient backend calls via `axios-retry` for transient failures
@@ -125,7 +126,7 @@ The SDK is under active development. Here's what's coming:
 ### In Progress
 - [x] Tsup bundler configuration for ESM/CJS exports
 - [ ] NPM publishing pipeline with provenance
-- [ ] Simulation wrappers for transaction cost estimation
+- [x] Simulation wrappers for transaction cost estimation (`TransactionPipeline`)
 - [x] Auto-retry logic for backend API endpoints (`axios-retry`)
 
 ### Planned Features

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,3 +26,46 @@ Fluent builder: `.setDepositor().setBeneficiary().setAmount().build()`
 - Default retry policy: 3 retries, exponential backoff (250ms base, 2000ms max cap).
 - Retry conditions: network errors, HTTP `429`, and HTTP `5xx` responses.
 - Non-transient `4xx` responses are returned without retry.
+
+## TransactionPipeline
+Unified pipeline for assembling, simulating, fee-adjusting, fee-bumping, and retrying
+Soroban transactions against RPC. Every method returns a `PipelineResult<T>`
+(`{ ok: true; data: T } | { ok: false; error: TrustFlowError }`) instead of throwing, so
+callers get a typed, actionable `error.code` (e.g. `ASSEMBLY_ERROR`, `SIMULATION_ERROR`,
+`FEE_BUMP_ERROR`, `SUBMISSION_ERROR`, `RETRY_EXHAUSTED`) without try/catch.
+
+- `new TransactionPipeline(client: TrustFlowClient)`
+- `.assemble(params)` — builds an unsigned transaction from a source account and operations
+- `.simulate(tx)` — simulates a transaction against Soroban RPC without mutating it
+- `.prepare(tx, options?)` — simulates and folds the footprint/auth/resource fee back onto
+  the transaction, applying a configurable safety multiplier (`resourceFeeMultiplier`,
+  default 1.1) on top of the RPC-reported `minResourceFee`; retries transient RPC failures
+  with exponential backoff
+- `.buildFeeBump(innerTx, { feeSource, baseFee? })` — wraps a transaction in a fee-bump
+  envelope
+- `.submit(tx, options?)` — broadcasts a signed transaction and polls for confirmation,
+  retrying transient submission failures with exponential backoff
+- `.run(params)` — convenience method chaining assemble → prepare → sign → submit; when
+  submission fails for a fee-related reason (`TRY_AGAIN_LATER`, insufficient fee) and
+  `submit.feeBump` is configured, automatically builds, signs, and resubmits a fee-bump
+  transaction before giving up
+
+```typescript
+import { TransactionPipeline, TrustFlowClient } from '@trustflow/sdk';
+
+const client = new TrustFlowClient({ contractId, network: 'TESTNET' });
+const pipeline = new TransactionPipeline(client);
+
+const result = await pipeline.run({
+  sourceAccount: sender.publicKey(),
+  operations: [contract.call('release', ...args)],
+  signers: [sender],
+  submit: { feeBump: { feeSource: sponsor } },
+});
+
+if (!result.ok) {
+  console.error(result.error.code, result.error.message);
+} else {
+  console.log('confirmed:', result.data.hash, 'feeBumped:', result.data.feeBumped);
+}
+```

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,11 @@ export type TrustFlowErrorCode =
   | 'MULTISIG_ALREADY_SIGNED'
   | 'MULTISIG_EXPIRED'
   | 'MULTISIG_INVALID_SIGNER'
-  | 'MULTISIG_XDR_ERROR';
+  | 'MULTISIG_XDR_ERROR'
+  | 'ASSEMBLY_ERROR'
+  | 'FEE_BUMP_ERROR'
+  | 'SUBMISSION_ERROR'
+  | 'RETRY_EXHAUSTED';
 
 export class TrustFlowError extends Error {
   readonly code: TrustFlowErrorCode;
@@ -59,5 +63,33 @@ export class TrustFlowError extends Error {
 
   static multiSigXdrError(detail: string): TrustFlowError {
     return new TrustFlowError(`Multi-sig XDR error: ${detail}`, 'MULTISIG_XDR_ERROR');
+  }
+
+  static assemblyFailed(detail: string, cause?: unknown): TrustFlowError {
+    return new TrustFlowError(`Transaction assembly failed: ${detail}`, 'ASSEMBLY_ERROR', cause);
+  }
+
+  static simulationFailed(detail: string, cause?: unknown): TrustFlowError {
+    return new TrustFlowError(`Simulation failed: ${detail}`, 'SIMULATION_ERROR', cause);
+  }
+
+  static feeBumpFailed(detail: string, cause?: unknown): TrustFlowError {
+    return new TrustFlowError(`Fee-bump construction failed: ${detail}`, 'FEE_BUMP_ERROR', cause);
+  }
+
+  static submissionFailed(detail: string, cause?: unknown): TrustFlowError {
+    return new TrustFlowError(
+      `Transaction submission failed: ${detail}`,
+      'SUBMISSION_ERROR',
+      cause,
+    );
+  }
+
+  static retryExhausted(stage: string, attempts: number, cause?: unknown): TrustFlowError {
+    return new TrustFlowError(
+      `Retries exhausted for ${stage} after ${attempts} attempt(s)`,
+      'RETRY_EXHAUSTED',
+      cause,
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,9 @@ export * from './auth';
 export * from './stellar';
 export * from './utils/validation';
 export * from './utils/format';
+export * from './tx-pipeline';
+export { TrustFlowClient } from './client';
+export { TrustFlowError } from './errors';
+export type { TrustFlowErrorCode } from './errors';
 
 export const SDK_VERSION = '0.1.0';

--- a/src/tx-pipeline/index.ts
+++ b/src/tx-pipeline/index.ts
@@ -1,0 +1,12 @@
+export { TransactionPipeline } from './pipeline';
+export type {
+  AssembleParams,
+  FeeBumpOptions,
+  PipelineResult,
+  PipelineSubmission,
+  PrepareOptions,
+  RetryPolicy,
+  RunPipelineParams,
+  SubmitOptions,
+  SubmittableTransaction,
+} from './types';

--- a/src/tx-pipeline/pipeline.ts
+++ b/src/tx-pipeline/pipeline.ts
@@ -1,0 +1,339 @@
+import {
+  BASE_FEE,
+  FeeBumpTransaction,
+  Transaction,
+  TransactionBuilder,
+  rpc,
+} from '@stellar/stellar-sdk';
+import type { TrustFlowClient } from '../client';
+import { TrustFlowError } from '../errors';
+import type {
+  AssembleParams,
+  FeeBumpOptions,
+  PipelineResult,
+  PipelineSubmission,
+  PrepareOptions,
+  RetryPolicy,
+  RunPipelineParams,
+  SubmitOptions,
+  SubmittableTransaction,
+} from './types';
+
+const DEFAULT_RETRY_POLICY: Required<RetryPolicy> = {
+  maxAttempts: 3,
+  baseDelayMs: 300,
+  maxDelayMs: 5000,
+};
+
+const DEFAULT_RESOURCE_FEE_MULTIPLIER = 1.1;
+const DEFAULT_POLL_INTERVAL_MS = 1500;
+const DEFAULT_POLL_ATTEMPTS = 10;
+
+function ok<T>(data: T): PipelineResult<T> {
+  return { ok: true, data };
+}
+
+function fail<T>(error: TrustFlowError): PipelineResult<T> {
+  return { ok: false, error };
+}
+
+const FEE_RELATED_PATTERN = /TRY_AGAIN_LATER|insufficient.?fee|tx_insufficient_fee/i;
+
+/**
+ * Fee-related failures are the only ones worth escalating to a fee-bump
+ * retry. `submit()` always surfaces a top-level `RETRY_EXHAUSTED` error, so
+ * the fee-related detail (e.g. `TRY_AGAIN_LATER`) must be read off the
+ * wrapped `cause`, not the outer message.
+ */
+function isFeeRelated(error: TrustFlowError): boolean {
+  const cause = error.cause instanceof Error ? error.cause.message : '';
+  return FEE_RELATED_PATTERN.test(`${error.message} ${cause}`);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  policy: RetryPolicy | undefined,
+  stage: string,
+): Promise<PipelineResult<T>> {
+  const { maxAttempts, baseDelayMs, maxDelayMs } = { ...DEFAULT_RETRY_POLICY, ...policy };
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return ok(await fn(attempt));
+    } catch (e) {
+      lastError = e;
+      if (attempt < maxAttempts) {
+        await sleep(Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs));
+      }
+    }
+  }
+
+  return fail(TrustFlowError.retryExhausted(stage, maxAttempts, lastError));
+}
+
+/**
+ * Unified pipeline for assembling, simulating, fee-adjusting, fee-bumping,
+ * and retrying Soroban transactions.
+ *
+ * Flow:
+ *  1. `assemble` — builds an unsigned transaction envelope from a source
+ *     account and one or more operations.
+ *  2. `prepare` — simulates the transaction against Soroban RPC and folds
+ *     the resulting footprint, auth entries, and resource fee back onto the
+ *     transaction (with retry/backoff on transient RPC failures).
+ *  3. `submit` — signs and broadcasts the transaction, polling for
+ *     confirmation, optionally escalating to a fee-bump transaction when the
+ *     network reports a fee-related rejection.
+ *  4. `run` — convenience method chaining all of the above.
+ *
+ * Every method returns a {@link PipelineResult}, never throws for expected
+ * failure modes, so callers get typed, actionable errors without try/catch.
+ *
+ * @example
+ * ```typescript
+ * const pipeline = new TransactionPipeline(client);
+ * const result = await pipeline.run({
+ *   sourceAccount: senderPublicKey,
+ *   operations: [contract.call('release', ...args)],
+ *   signers: [senderKeypair],
+ *   submit: { feeBump: { feeSource: sponsorKeypair } },
+ * });
+ *
+ * if (!result.ok) {
+ *   console.error(result.error.code, result.error.message);
+ *   return;
+ * }
+ * console.log('confirmed:', result.data.hash);
+ * ```
+ */
+export class TransactionPipeline {
+  private readonly server: rpc.Server;
+
+  constructor(private readonly client: TrustFlowClient) {
+    this.server = new rpc.Server(client.rpcUrl);
+  }
+
+  /**
+   * Builds an unsigned transaction envelope from a source account and one or
+   * more operations. Does not contact Soroban RPC beyond fetching the
+   * source account's current sequence number.
+   *
+   * @param params - Source account, operations, and optional memo/timeout/fee
+   */
+  async assemble(params: AssembleParams): Promise<PipelineResult<Transaction>> {
+    try {
+      const account = await this.server.getAccount(params.sourceAccount);
+      const builder = new TransactionBuilder(account, {
+        fee: params.fee ?? BASE_FEE,
+        networkPassphrase: this.client.getNetworkPassphrase(),
+      }).setTimeout(params.timeoutSeconds ?? 30);
+
+      for (const operation of params.operations) {
+        builder.addOperation(operation);
+      }
+      if (params.memo) {
+        builder.addMemo(params.memo);
+      }
+
+      return ok(builder.build());
+    } catch (e) {
+      return fail(
+        TrustFlowError.assemblyFailed(
+          `could not assemble transaction for ${params.sourceAccount}`,
+          e,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Simulates a transaction against Soroban RPC without mutating it.
+   * Useful for inspecting cost/return value before committing to `prepare`.
+   *
+   * @param tx - The transaction to simulate
+   */
+  async simulate(tx: Transaction): Promise<PipelineResult<rpc.Api.SimulateTransactionResponse>> {
+    try {
+      const response = await this.server.simulateTransaction(tx);
+      if (rpc.Api.isSimulationError(response)) {
+        return fail(TrustFlowError.simulationFailed(response.error));
+      }
+      return ok(response);
+    } catch (e) {
+      return fail(TrustFlowError.simulationFailed('simulateTransaction request failed', e));
+    }
+  }
+
+  /**
+   * Simulates the transaction and folds the resulting footprint, auth
+   * entries, and resource fee back onto a new copy of it, applying a safety
+   * multiplier on top of the RPC-reported minimum resource fee. Retries on
+   * transient RPC failures using exponential backoff.
+   *
+   * @param tx - The assembled, unsigned transaction to prepare
+   * @param options - Resource fee multiplier and retry policy
+   */
+  async prepare(tx: Transaction, options?: PrepareOptions): Promise<PipelineResult<Transaction>> {
+    const multiplier = options?.resourceFeeMultiplier ?? DEFAULT_RESOURCE_FEE_MULTIPLIER;
+
+    return withRetry(
+      async () => {
+        const simulation = await this.server.simulateTransaction(tx);
+        if (rpc.Api.isSimulationError(simulation)) {
+          throw TrustFlowError.simulationFailed(simulation.error);
+        }
+
+        // `assembleTransaction` reads the resource fee off `transactionData`
+        // itself (not `minResourceFee`), so the headroom must be written
+        // onto the SorobanTransactionData builder for it to take effect.
+        const paddedFee = Math.ceil(Number(simulation.minResourceFee) * multiplier).toString();
+        simulation.transactionData.setResourceFee(paddedFee);
+
+        return rpc.assembleTransaction(tx, { ...simulation, minResourceFee: paddedFee }).build();
+      },
+      options,
+      'prepare',
+    );
+  }
+
+  /**
+   * Wraps an already-signed (or to-be-signed) inner transaction in a
+   * fee-bump envelope, paid for by `options.feeSource`.
+   *
+   * @param innerTx - The inner transaction to wrap
+   * @param options - Fee source and base fee for the fee-bump envelope
+   */
+  buildFeeBump(innerTx: Transaction, options: FeeBumpOptions): PipelineResult<FeeBumpTransaction> {
+    try {
+      const baseFee = options.baseFee ?? String(Number(BASE_FEE) * 10);
+      const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+        options.feeSource,
+        baseFee,
+        innerTx,
+        this.client.getNetworkPassphrase(),
+      );
+      return ok(feeBump);
+    } catch (e) {
+      return fail(TrustFlowError.feeBumpFailed('could not build fee-bump transaction', e));
+    }
+  }
+
+  /**
+   * Broadcasts a signed transaction and polls until it is confirmed on
+   * ledger. Retries transient submission failures with exponential backoff.
+   *
+   * @param tx - A fully signed transaction or fee-bump transaction
+   * @param options - Poll interval/attempts and retry policy
+   */
+  async submit(
+    tx: SubmittableTransaction,
+    options?: SubmitOptions,
+  ): Promise<PipelineResult<PipelineSubmission>> {
+    return withRetry(
+      async (attempt) => {
+        const sendResult = await this.server.sendTransaction(tx);
+
+        if (sendResult.status === 'ERROR') {
+          throw TrustFlowError.submissionFailed(
+            `node rejected transaction (${sendResult.hash})`,
+            sendResult.errorResult,
+          );
+        }
+        if (sendResult.status === 'TRY_AGAIN_LATER') {
+          throw TrustFlowError.submissionFailed('node reported TRY_AGAIN_LATER');
+        }
+
+        const ledger = await this.pollForConfirmation(sendResult.hash, options);
+
+        return {
+          hash: sendResult.hash,
+          ledger,
+          feeBumped: tx instanceof FeeBumpTransaction,
+          attempts: attempt,
+          feeCharged: tx.fee,
+        };
+      },
+      options,
+      'submit',
+    );
+  }
+
+  /**
+   * Runs the full pipeline: assemble, prepare (simulate + auto-adjust
+   * resource fee), sign, and submit. If the initial submission fails for a
+   * fee-related reason and `submit.feeBump` is configured, automatically
+   * builds and resubmits a fee-bump transaction before giving up.
+   *
+   * @param params - Assembly, signing, prepare, and submit configuration
+   */
+  async run(params: RunPipelineParams): Promise<PipelineResult<PipelineSubmission>> {
+    const assembled = await this.assemble(params);
+    if (!assembled.ok) {
+      return assembled;
+    }
+
+    const prepared = await this.prepare(assembled.data, params.prepare);
+    if (!prepared.ok) {
+      return prepared;
+    }
+
+    prepared.data.sign(...params.signers);
+
+    const submitted = await this.submit(prepared.data, params.submit);
+    if (submitted.ok) {
+      return submitted;
+    }
+
+    const feeBumpOptions = params.submit?.feeBump;
+    if (!feeBumpOptions || !isFeeRelated(submitted.error)) {
+      return submitted;
+    }
+
+    const feeBumped = this.buildFeeBump(prepared.data, feeBumpOptions);
+    if (!feeBumped.ok) {
+      return feeBumped;
+    }
+
+    feeBumped.data.sign(feeBumpOptions.feeSource);
+
+    const escalatedSubmission = await this.submit(feeBumped.data, {
+      ...params.submit,
+      feeBump: undefined,
+    });
+    if (!escalatedSubmission.ok) {
+      return escalatedSubmission;
+    }
+
+    return ok({ ...escalatedSubmission.data, feeBumped: true });
+  }
+
+  private async pollForConfirmation(
+    hash: string,
+    options?: SubmitOptions,
+  ): Promise<number | undefined> {
+    const attempts = options?.pollAttempts ?? DEFAULT_POLL_ATTEMPTS;
+    const intervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+    for (let i = 0; i < attempts; i++) {
+      const result = await this.server.getTransaction(hash);
+
+      if (result.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+        return result.ledger;
+      }
+      if (result.status === rpc.Api.GetTransactionStatus.FAILED) {
+        throw TrustFlowError.submissionFailed(`transaction ${hash} failed on-chain`);
+      }
+
+      if (i < attempts - 1) {
+        await sleep(intervalMs);
+      }
+    }
+
+    throw TrustFlowError.submissionFailed(`timed out waiting for transaction ${hash} to confirm`);
+  }
+}

--- a/src/tx-pipeline/types.ts
+++ b/src/tx-pipeline/types.ts
@@ -1,0 +1,97 @@
+import type { FeeBumpTransaction, Keypair, Memo, Transaction, xdr } from '@stellar/stellar-sdk';
+import type { TrustFlowError } from '../errors';
+
+/**
+ * Discriminated result type returned by every pipeline stage. Mirrors the
+ * SDK-wide `SDKResult<T>` convention, but carries a typed {@link TrustFlowError}
+ * (with a stable `code`) instead of a bare string, so callers can branch on
+ * failure cause programmatically rather than by parsing an error message.
+ */
+export type PipelineResult<T> = { ok: true; data: T } | { ok: false; error: TrustFlowError };
+
+/**
+ * Controls retry/backoff behaviour for a single pipeline stage
+ * (simulate+assemble, or submit).
+ */
+export interface RetryPolicy {
+  /** Maximum number of attempts, including the first. Defaults to 3. */
+  maxAttempts?: number;
+  /** Base delay in ms used for exponential backoff. Defaults to 300. */
+  baseDelayMs?: number;
+  /** Upper bound applied to any single backoff delay. Defaults to 5000. */
+  maxDelayMs?: number;
+}
+
+/** Parameters required to assemble an unsigned transaction envelope. */
+export interface AssembleParams {
+  /** Public key (G...) of the account that will source and pay the base fee for the transaction. */
+  sourceAccount: string;
+  /** One or more operations to include, typically `contract.call(...)`. */
+  operations: xdr.Operation[];
+  /** Optional transaction memo. */
+  memo?: Memo;
+  /** Validity window, in seconds, from assembly time. Defaults to 30. */
+  timeoutSeconds?: number;
+  /** Base inclusion fee in stroops, before Soroban resource fees are added. Defaults to `BASE_FEE`. */
+  fee?: string;
+}
+
+/** Options controlling how simulation results are folded back into a transaction. */
+export interface PrepareOptions extends RetryPolicy {
+  /**
+   * Safety headroom applied on top of the RPC-reported `minResourceFee`, to
+   * absorb small state changes between simulation and submission.
+   * Defaults to 1.1 (10% headroom).
+   */
+  resourceFeeMultiplier?: number;
+}
+
+/** Configuration for escalating a submission into a fee-bumped transaction. */
+export interface FeeBumpOptions {
+  /** Keypair of the account that will pay the bumped fee and sign the fee-bump envelope. */
+  feeSource: Keypair;
+  /** Fee in stroops for the fee-bump envelope. Defaults to 10x `BASE_FEE`. */
+  baseFee?: string;
+}
+
+/** Options controlling submission, on-chain confirmation polling, and fee-bump escalation. */
+export interface SubmitOptions extends RetryPolicy {
+  /** Interval between `getTransaction` polls while awaiting confirmation. Defaults to 1500ms. */
+  pollIntervalMs?: number;
+  /** Maximum number of confirmation polls before timing out. Defaults to 10. */
+  pollAttempts?: number;
+  /**
+   * When the initial submission fails for a fee-related reason (the node
+   * reports `TRY_AGAIN_LATER` or rejects the transaction for insufficient
+   * fee), automatically build and resubmit a fee-bump transaction using
+   * this configuration.
+   */
+  feeBump?: FeeBumpOptions;
+}
+
+/** Outcome of a successfully confirmed submission. */
+export interface PipelineSubmission {
+  /** Hex-encoded transaction hash. */
+  hash: string;
+  /** Ledger sequence the transaction was included in, if known. */
+  ledger?: number;
+  /** Whether the confirmed transaction was a fee-bump escalation. */
+  feeBumped: boolean;
+  /** Total submission attempts made before confirmation. */
+  attempts: number;
+  /** Final fee (stroops) charged on the confirmed transaction envelope. */
+  feeCharged: string;
+}
+
+/** End-to-end parameters for {@link TransactionPipeline.run}. */
+export interface RunPipelineParams extends AssembleParams {
+  /** Keypair(s) that must sign the assembled inner transaction. */
+  signers: Keypair[];
+  /** Options for the simulate+assemble stage. */
+  prepare?: PrepareOptions;
+  /** Options for the submit+confirm stage, including fee-bump escalation. */
+  submit?: SubmitOptions;
+}
+
+/** Union of transaction types the pipeline can submit. */
+export type SubmittableTransaction = Transaction | FeeBumpTransaction;

--- a/tests/tx-pipeline.test.ts
+++ b/tests/tx-pipeline.test.ts
@@ -1,0 +1,354 @@
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  SorobanDataBuilder,
+  Transaction,
+  TransactionBuilder,
+  rpc,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { TransactionPipeline } from '../src/tx-pipeline';
+import { TrustFlowClient } from '../src/client';
+import { TrustFlowError } from '../src/errors';
+
+const CONTRACT_ID = 'CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5';
+
+function makeClient(): TrustFlowClient {
+  return new TrustFlowClient({ contractId: CONTRACT_ID, network: 'TESTNET' });
+}
+
+function expectValidEnvelopeXdr(xdrString: string): void {
+  expect(() => xdr.TransactionEnvelope.fromXDR(xdrString, 'base64')).not.toThrow();
+}
+
+function buildUnsignedTx(source: string, fee = BASE_FEE): Transaction {
+  const account = new Account(source, '100');
+  const contract = new Contract(CONTRACT_ID);
+  return new TransactionBuilder(account, { fee, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('increment'))
+    .setTimeout(30)
+    .build();
+}
+
+function simSuccess(minResourceFee: string): rpc.Api.SimulateTransactionSuccessResponse {
+  return {
+    id: '1',
+    latestLedger: 100,
+    events: [],
+    _parsed: true,
+    transactionData: new SorobanDataBuilder(),
+    minResourceFee,
+    result: { auth: [], retval: xdr.ScVal.scvVoid() },
+  };
+}
+
+function simError(message: string): rpc.Api.SimulateTransactionErrorResponse {
+  return { id: '1', latestLedger: 100, events: [], _parsed: true, error: message };
+}
+
+describe('TransactionPipeline.assemble', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('assembles a transaction whose XDR round-trips', async () => {
+    const source = Keypair.random().publicKey();
+    jest.spyOn(rpc.Server.prototype, 'getAccount').mockResolvedValue(new Account(source, '100'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.assemble({
+      sourceAccount: source,
+      operations: [new Contract(CONTRACT_ID).call('increment')],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toBeInstanceOf(Transaction);
+    expectValidEnvelopeXdr(result.data.toXDR());
+    expect(() => TransactionBuilder.fromXDR(result.data.toXDR(), Networks.TESTNET)).not.toThrow();
+  });
+
+  it('surfaces a typed ASSEMBLY_ERROR when the source account cannot be loaded', async () => {
+    jest.spyOn(rpc.Server.prototype, 'getAccount').mockRejectedValue(new Error('account not found'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.assemble({
+      sourceAccount: Keypair.random().publicKey(),
+      operations: [new Contract(CONTRACT_ID).call('increment')],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(TrustFlowError);
+    expect(result.error.code).toBe('ASSEMBLY_ERROR');
+  });
+});
+
+describe('TransactionPipeline.prepare', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('pads the resource fee reported by simulation onto the transaction fee', async () => {
+    const source = Keypair.random().publicKey();
+    const tx = buildUnsignedTx(source);
+    jest.spyOn(rpc.Server.prototype, 'simulateTransaction').mockResolvedValue(simSuccess('1000'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.prepare(tx, { resourceFeeMultiplier: 2 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Number(result.data.fee)).toBe(Number(BASE_FEE) + 2000);
+    expectValidEnvelopeXdr(result.data.toXDR());
+  });
+
+  it('retries transient simulation failures before succeeding', async () => {
+    const tx = buildUnsignedTx(Keypair.random().publicKey());
+    const spy = jest
+      .spyOn(rpc.Server.prototype, 'simulateTransaction')
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce(simSuccess('500'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.prepare(tx, { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 1 });
+
+    expect(result.ok).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('surfaces RETRY_EXHAUSTED with the underlying cause once retries run out', async () => {
+    const tx = buildUnsignedTx(Keypair.random().publicKey());
+    jest.spyOn(rpc.Server.prototype, 'simulateTransaction').mockRejectedValue(new Error('rpc down'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.prepare(tx, { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 1 });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('RETRY_EXHAUSTED');
+    expect(result.error.cause).toBeInstanceOf(Error);
+  });
+
+  it('wraps a simulation error response as a typed SIMULATION_ERROR cause', async () => {
+    const tx = buildUnsignedTx(Keypair.random().publicKey());
+    jest
+      .spyOn(rpc.Server.prototype, 'simulateTransaction')
+      .mockResolvedValue(simError('Error(Contract, #1)'));
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.prepare(tx, { maxAttempts: 1 });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('RETRY_EXHAUSTED');
+    const cause = result.error.cause as TrustFlowError;
+    expect(cause.code).toBe('SIMULATION_ERROR');
+    expect(cause.message).toContain('Error(Contract, #1)');
+  });
+});
+
+describe('TransactionPipeline.buildFeeBump', () => {
+  it('builds a fee-bump envelope that round-trips through TransactionBuilder.fromXDR', () => {
+    const sourceKeypair = Keypair.random();
+    const feeSource = Keypair.random();
+    const inner = buildUnsignedTx(sourceKeypair.publicKey());
+    inner.sign(sourceKeypair);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = pipeline.buildFeeBump(inner, { feeSource, baseFee: '1000' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    result.data.sign(feeSource);
+    expect(result.data).toBeInstanceOf(FeeBumpTransaction);
+
+    const envelope = xdr.TransactionEnvelope.fromXDR(result.data.toXDR(), 'base64');
+    expect(envelope.switch()).toEqual(xdr.EnvelopeType.envelopeTypeTxFeeBump());
+
+    const decoded = TransactionBuilder.fromXDR(result.data.toXDR(), Networks.TESTNET);
+    expect(decoded).toBeInstanceOf(FeeBumpTransaction);
+  });
+
+  it('surfaces a typed FEE_BUMP_ERROR when the base fee is below the network minimum', () => {
+    const sourceKeypair = Keypair.random();
+    const inner = buildUnsignedTx(sourceKeypair.publicKey());
+    inner.sign(sourceKeypair);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = pipeline.buildFeeBump(inner, { feeSource: Keypair.random(), baseFee: '1' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(TrustFlowError);
+    expect(result.error.code).toBe('FEE_BUMP_ERROR');
+  });
+});
+
+describe('TransactionPipeline.submit', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('confirms a transaction that is accepted and included on the first attempt', async () => {
+    const sourceKeypair = Keypair.random();
+    const tx = buildUnsignedTx(sourceKeypair.publicKey());
+    tx.sign(sourceKeypair);
+
+    jest.spyOn(rpc.Server.prototype, 'sendTransaction').mockResolvedValue({
+      status: 'PENDING',
+      hash: 'deadbeef',
+      latestLedger: 1,
+      latestLedgerCloseTime: 1,
+    });
+    jest.spyOn(rpc.Server.prototype, 'getTransaction').mockResolvedValue({
+      status: rpc.Api.GetTransactionStatus.SUCCESS,
+      ledger: 42,
+    } as unknown as rpc.Api.GetTransactionResponse);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.submit(tx, { pollIntervalMs: 1 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({
+      hash: 'deadbeef',
+      ledger: 42,
+      feeBumped: false,
+      attempts: 1,
+      feeCharged: tx.fee,
+    });
+  });
+
+  it('retries after TRY_AGAIN_LATER and succeeds on the next attempt', async () => {
+    const sourceKeypair = Keypair.random();
+    const tx = buildUnsignedTx(sourceKeypair.publicKey());
+    tx.sign(sourceKeypair);
+
+    const sendSpy = jest
+      .spyOn(rpc.Server.prototype, 'sendTransaction')
+      .mockResolvedValueOnce({
+        status: 'TRY_AGAIN_LATER',
+        hash: 'deadbeef',
+        latestLedger: 1,
+        latestLedgerCloseTime: 1,
+      })
+      .mockResolvedValueOnce({
+        status: 'PENDING',
+        hash: 'deadbeef',
+        latestLedger: 2,
+        latestLedgerCloseTime: 2,
+      });
+    jest.spyOn(rpc.Server.prototype, 'getTransaction').mockResolvedValue({
+      status: rpc.Api.GetTransactionStatus.SUCCESS,
+      ledger: 43,
+    } as unknown as rpc.Api.GetTransactionResponse);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.submit(tx, { maxAttempts: 2, baseDelayMs: 1, pollIntervalMs: 1 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.attempts).toBe(2);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces RETRY_EXHAUSTED wrapping a SUBMISSION_ERROR when the node rejects the transaction', async () => {
+    const sourceKeypair = Keypair.random();
+    const tx = buildUnsignedTx(sourceKeypair.publicKey());
+    tx.sign(sourceKeypair);
+
+    jest.spyOn(rpc.Server.prototype, 'sendTransaction').mockResolvedValue({
+      status: 'ERROR',
+      hash: 'deadbeef',
+      latestLedger: 1,
+      latestLedgerCloseTime: 1,
+    });
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.submit(tx, { maxAttempts: 2, baseDelayMs: 1 });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('RETRY_EXHAUSTED');
+    expect((result.error.cause as TrustFlowError).code).toBe('SUBMISSION_ERROR');
+  });
+});
+
+describe('TransactionPipeline.run', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('assembles, prepares, signs, and submits a transaction end-to-end', async () => {
+    const source = Keypair.random();
+    jest.spyOn(rpc.Server.prototype, 'getAccount').mockResolvedValue(new Account(source.publicKey(), '100'));
+    jest.spyOn(rpc.Server.prototype, 'simulateTransaction').mockResolvedValue(simSuccess('500'));
+    jest.spyOn(rpc.Server.prototype, 'sendTransaction').mockResolvedValue({
+      status: 'PENDING',
+      hash: 'cafebabe',
+      latestLedger: 1,
+      latestLedgerCloseTime: 1,
+    });
+    jest.spyOn(rpc.Server.prototype, 'getTransaction').mockResolvedValue({
+      status: rpc.Api.GetTransactionStatus.SUCCESS,
+      ledger: 7,
+    } as unknown as rpc.Api.GetTransactionResponse);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.run({
+      sourceAccount: source.publicKey(),
+      operations: [new Contract(CONTRACT_ID).call('increment')],
+      signers: [source],
+      submit: { pollIntervalMs: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.feeBumped).toBe(false);
+    expect(result.data.hash).toBe('cafebabe');
+  });
+
+  it('escalates to a fee-bump transaction when submission is fee-rejected', async () => {
+    const source = Keypair.random();
+    const sponsor = Keypair.random();
+
+    jest.spyOn(rpc.Server.prototype, 'getAccount').mockResolvedValue(new Account(source.publicKey(), '100'));
+    jest.spyOn(rpc.Server.prototype, 'simulateTransaction').mockResolvedValue(simSuccess('500'));
+
+    const sendSpy = jest
+      .spyOn(rpc.Server.prototype, 'sendTransaction')
+      .mockResolvedValueOnce({
+        status: 'TRY_AGAIN_LATER',
+        hash: 'first',
+        latestLedger: 1,
+        latestLedgerCloseTime: 1,
+      })
+      .mockResolvedValueOnce({
+        status: 'PENDING',
+        hash: 'second',
+        latestLedger: 2,
+        latestLedgerCloseTime: 2,
+      });
+    jest.spyOn(rpc.Server.prototype, 'getTransaction').mockResolvedValue({
+      status: rpc.Api.GetTransactionStatus.SUCCESS,
+      ledger: 9,
+    } as unknown as rpc.Api.GetTransactionResponse);
+
+    const pipeline = new TransactionPipeline(makeClient());
+    const result = await pipeline.run({
+      sourceAccount: source.publicKey(),
+      operations: [new Contract(CONTRACT_ID).call('increment')],
+      signers: [source],
+      submit: {
+        maxAttempts: 1,
+        pollIntervalMs: 1,
+        feeBump: { feeSource: sponsor, baseFee: '5000' },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.feeBumped).toBe(true);
+    expect(result.data.hash).toBe('second');
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

TrustFlow SDK had no unified way to assemble, simulate, and submit Soroban transactions. The existing `contract/simulate.ts`, `contract/invoke.ts`, and `stellar/rpc.ts` modules were incomplete stubs — and, incidentally, import a `SorobanRpc` symbol that doesn't exist in the installed `@stellar/stellar-sdk` v15 (a pre-existing bug worth a follow-up cleanup issue). There was also no fee-bump or retry support anywhere in the codebase, and no typed way to distinguish assembly failures from simulation failures from submission failures.

## Solution

Adds `TransactionPipeline` (`src/tx-pipeline/`), a unified pipeline covering:

- **`assemble()`** — builds an unsigned transaction from a source account + operations
- **`simulate()`** — read-only Soroban RPC simulation
- **`prepare()`** — simulates and folds footprint/auth/resource fee back onto the transaction, padding the RPC's `minResourceFee` with a configurable safety multiplier (default 10%); retries transient RPC failures with exponential backoff
- **`buildFeeBump()`** — wraps a transaction in a fee-bump envelope
- **`submit()`** — broadcasts, polls for confirmation, retries transient failures
- **`run()`** — chains all of the above end-to-end, auto-escalating to a signed fee-bump resubmission when the network reports `TRY_AGAIN_LATER` or an insufficient-fee rejection

Every method returns `PipelineResult<T>` (`{ ok: true; data: T } | { ok: false; error: TrustFlowError }`) instead of throwing, giving callers a typed, actionable `error.code` (`ASSEMBLY_ERROR`, `SIMULATION_ERROR`, `FEE_BUMP_ERROR`, `SUBMISSION_ERROR`, `RETRY_EXHAUSTED`) without try/catch — matching the SDK's existing `SDKResult` convention.

Also exports `TrustFlowClient` and `TrustFlowError` from the package root (`src/index.ts`) — both were missing despite being documented in the README's own usage examples, and the pipeline is unusable without them.

No new dependencies were required — `@stellar/stellar-sdk` (already a dependency) provides everything needed (`rpc.Server`, `TransactionBuilder.buildFeeBumpTransaction`, etc.).

## Usage

```typescript
import { TransactionPipeline, TrustFlowClient } from '@trustflow/sdk';

const client = new TrustFlowClient({ contractId, network: 'TESTNET' });
const pipeline = new TransactionPipeline(client);

const result = await pipeline.run({
  sourceAccount: sender.publicKey(),
  operations: [contract.call('release', ...args)],
  signers: [sender],
  submit: { feeBump: { feeSource: sponsor } },
});

if (!result.ok) {
  console.error(result.error.code, result.error.message);
} else {
  console.log('confirmed:', result.data.hash, 'feeBumped:', result.data.feeBumped);
}
```

## Testing

- 13 new Jest tests (`tests/tx-pipeline.test.ts`) covering:
  - XDR round-trips for assembled and fee-bump transactions
  - Resource-fee padding math against a mocked simulation response
  - Retry/backoff behavior for both `prepare()` and `submit()`
  - Fee-bump construction, including the real `stellar-base` validation-error path
  - End-to-end `run()` happy path and fee-bump escalation path
- Full suite: **119/119 tests passing** (20 suites)
- `npm run lint` → 0 errors (21 pre-existing warnings elsewhere, untouched)
- `npm run build` → tsup builds CJS + ESM + `.d.ts` cleanly

## Notes for reviewers

- **Potential edge case**: `feeBumpOptions.feeSource` requires a `Keypair` (not just a public key) so `run()` can sign the escalated fee-bump inline. Offline/hardware-signer flows should call `buildFeeBump()` / `submit()` directly instead of `run()`.
- **No merge conflicts expected** — this is a purely additive new directory (`src/tx-pipeline/`) plus two small, non-overlapping edits to `src/errors.ts` and `src/index.ts`.
- **Pre-existing coverage threshold**: `npm run test:coverage` already fails the 60% global threshold on `main` (unaffected by this PR — CI only runs plain `npm test`, and this PR improves aggregate coverage).
- **Follow-up flagged, not fixed here**: `src/contract/simulate.ts`, `src/contract/invoke.ts`, and `src/contract/read.ts` import a `SorobanRpc` symbol that doesn't exist in `@stellar/stellar-sdk` v15 (should be `rpc`). Left out of scope for this PR to keep the diff focused.

Closes #68
