### PR TITLE
feat(sdk): export Zod validation schemas from package root (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+- Exported the Zod validation schemas from `src/schemas.ts` (`StellarAddressSchema`,
+  `ContractIdSchema`, `StroopsSchema`, `NetworkSchema`, `CreateEscrowSchema`,
+  `ReleaseEscrowSchema`, `DisputeEscrowSchema`, `ClientConfigSchema`, plus the `*Input` inferred
+  types) from the package root (#45) so consumers — notably frontend form validation — can reuse
+  the same rules the SDK enforces internally instead of duplicating them. The schemas' inferred
+  `Network` and `ClientConfig` type aliases are intentionally **not** re-exported from the root
+  barrel: those names already exist as plain TS types in `src/types.ts`, and re-exporting both
+  via `export *` produces an ambiguous-export error; import them directly from `../schemas` if
+  needed. No new runtime dependency — `zod` was already added in #45.
 - **Breaking changes: none.** Everything below is additive; existing `saveSession`/`loadSession`/
   `clearSession` and `MultiSigEscrowClient` call signatures are unchanged. See the "Compatibility
   & migration" note at the top of `docs/spikes/issue-79-retry-session-multisig.md`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,28 @@ Fluent builder: `.setDepositor().setBeneficiary().setAmount().build()`
 - `requestChallenge(apiUrl, address, options?)` — get signing challenge with retry-aware backend transport
 - `verifyAndGetToken(apiUrl, address, signature, options?)` — exchange signature for JWT with retry-aware backend transport
 
+## Validation Schemas
+Zod runtime schemas (`src/schemas.ts`) — the same ones the SDK uses internally — exported from
+the package root so frontend code can validate form/input data before calling the SDK, without
+re-implementing the rules:
+
+- `StellarAddressSchema`, `ContractIdSchema`, `StroopsSchema`, `NetworkSchema` — primitives
+- `CreateEscrowSchema`, `ReleaseEscrowSchema`, `DisputeEscrowSchema` — escrow operation inputs
+- `ClientConfigSchema` — `new TrustFlowClient(...)` config
+- Inferred types `CreateEscrowInput`, `ReleaseEscrowInput`, `DisputeEscrowInput` are exported
+  alongside their schemas. (`Network`/`ClientConfig` are not re-exported under those names from
+  the root — they'd collide with the existing plain TS types of the same name; derive them
+  yourself with `z.infer<typeof ClientConfigSchema>` / `z.infer<typeof NetworkSchema>` if needed.)
+
+```typescript
+import { CreateEscrowSchema } from '@trustflow/sdk';
+
+const result = CreateEscrowSchema.safeParse(formValues);
+if (!result.success) {
+  showFormErrors(result.error.flatten());
+}
+```
+
 ## Backend API Retry Behavior
 - Backend API endpoints now use a shared Axios transport configured with `axios-retry`.
 - Default retry policy: 3 retries, exponential backoff (250ms base, 2000ms max cap).

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,20 @@ export { TrustFlowClient } from './client';
 export { TrustFlowError } from './errors';
 export type { TrustFlowErrorCode } from './errors';
 
+// Zod runtime validation schemas (#45) — re-exported by name rather than
+// `export *` because `Network` and `ClientConfig` already exist as plain
+// TS types from './types'; only the schema objects and the composite
+// "*Input" types are exposed here to avoid ambiguous re-exports.
+export {
+  StellarAddressSchema,
+  ContractIdSchema,
+  StroopsSchema,
+  NetworkSchema,
+  CreateEscrowSchema,
+  ReleaseEscrowSchema,
+  DisputeEscrowSchema,
+  ClientConfigSchema,
+} from './schemas';
+export type { CreateEscrowInput, ReleaseEscrowInput, DisputeEscrowInput } from './schemas';
+
 export const SDK_VERSION = '0.1.0';

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,19 @@
 /**
  * Zod runtime validation schemas for TrustFlow SDK (#45).
- * Import these to validate inputs at runtime and get typed results.
+ *
+ * These are the same schemas the SDK uses internally to validate inputs
+ * before building contract calls. They are exported from the package root
+ * so consumers (including frontend form/validation code) can reuse them
+ * directly instead of re-implementing the same rules, e.g.:
+ *
+ * ```typescript
+ * import { CreateEscrowSchema } from '@trustflow/sdk';
+ *
+ * const result = CreateEscrowSchema.safeParse(formValues);
+ * if (!result.success) {
+ *   showFormErrors(result.error.flatten());
+ * }
+ * ```
  */
 import { z } from 'zod';
 
@@ -9,20 +22,25 @@ const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
 
 // ── Primitives ────────────────────────────────────────────────────────────────
 
+/** Validates a Stellar account address (`G...`, 56 chars, base32). */
 export const StellarAddressSchema = z
   .string()
   .regex(STELLAR_ADDRESS_RE, 'Invalid Stellar address (must start with G and be 56 chars)');
 
+/** Validates a Soroban contract ID (`C...`, 56 chars, base32). */
 export const ContractIdSchema = z
   .string()
   .regex(CONTRACT_ID_RE, 'Invalid contract ID (must start with C and be 56 chars)');
 
+/** Validates a positive amount denominated in stroops (1 XLM = 10,000,000 stroops). */
 export const StroopsSchema = z.bigint().positive('Amount must be positive');
 
+/** Validates a supported TrustFlow network name. */
 export const NetworkSchema = z.enum(['MAINNET', 'TESTNET', 'FUTURENET']);
 
 // ── Escrow ────────────────────────────────────────────────────────────────────
 
+/** Validates the input to `escrow.create()`. */
 export const CreateEscrowSchema = z.object({
   sender: StellarAddressSchema,
   recipient: StellarAddressSchema,
@@ -31,12 +49,14 @@ export const CreateEscrowSchema = z.object({
   memo: z.string().max(28).optional(),
 });
 
+/** Validates the input to `escrow.release()`. */
 export const ReleaseEscrowSchema = z.object({
   escrowId: z.string().min(1),
   recipient: StellarAddressSchema,
   network: NetworkSchema.default('TESTNET'),
 });
 
+/** Validates the input to `escrow.dispute()`. */
 export const DisputeEscrowSchema = z.object({
   escrowId: z.string().min(1),
   reason: z.string().min(10, 'Dispute reason must be at least 10 characters'),
@@ -46,6 +66,7 @@ export const DisputeEscrowSchema = z.object({
 
 // ── Client config ─────────────────────────────────────────────────────────────
 
+/** Validates the config object passed to `new TrustFlowClient(...)`. */
 export const ClientConfigSchema = z.object({
   network: NetworkSchema.default('TESTNET'),
   contractId: ContractIdSchema,

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,0 +1,150 @@
+import {
+  StellarAddressSchema,
+  ContractIdSchema,
+  StroopsSchema,
+  NetworkSchema,
+  CreateEscrowSchema,
+  ReleaseEscrowSchema,
+  DisputeEscrowSchema,
+  ClientConfigSchema,
+} from '../src';
+
+const ADDR_A = 'G' + 'A'.repeat(55);
+const ADDR_B = 'G' + 'B'.repeat(55);
+const CONTRACT_ID = 'C' + 'A'.repeat(55);
+
+describe('exported Zod schemas', () => {
+  it('are reachable from the package root (not just src/schemas)', () => {
+    expect(StellarAddressSchema).toBeDefined();
+    expect(CreateEscrowSchema).toBeDefined();
+  });
+
+  describe('StellarAddressSchema', () => {
+    it('accepts a well-formed address', () => {
+      expect(StellarAddressSchema.safeParse(ADDR_A).success).toBe(true);
+    });
+
+    it.each(['not-an-address', 'A' + 'A'.repeat(55), 'G' + 'A'.repeat(54)])(
+      'rejects %s',
+      (value) => {
+        expect(StellarAddressSchema.safeParse(value).success).toBe(false);
+      },
+    );
+  });
+
+  describe('ContractIdSchema', () => {
+    it('accepts a well-formed contract id', () => {
+      expect(ContractIdSchema.safeParse(CONTRACT_ID).success).toBe(true);
+    });
+
+    it('rejects an address prefixed with G instead of C', () => {
+      expect(ContractIdSchema.safeParse(ADDR_A).success).toBe(false);
+    });
+  });
+
+  describe('StroopsSchema', () => {
+    it('accepts a positive bigint', () => {
+      expect(StroopsSchema.safeParse(1_000_000n).success).toBe(true);
+    });
+
+    it('rejects zero, negative, and non-bigint values', () => {
+      expect(StroopsSchema.safeParse(0n).success).toBe(false);
+      expect(StroopsSchema.safeParse(-1n).success).toBe(false);
+      expect(StroopsSchema.safeParse(1000).success).toBe(false);
+    });
+  });
+
+  describe('NetworkSchema', () => {
+    it.each(['MAINNET', 'TESTNET', 'FUTURENET'])('accepts %s', (network) => {
+      expect(NetworkSchema.safeParse(network).success).toBe(true);
+    });
+
+    it('rejects an unsupported network', () => {
+      expect(NetworkSchema.safeParse('DEVNET').success).toBe(false);
+    });
+  });
+
+  describe('CreateEscrowSchema', () => {
+    it('parses valid input and defaults network to TESTNET', () => {
+      const result = CreateEscrowSchema.parse({
+        sender: ADDR_A,
+        recipient: ADDR_B,
+        amount: 1_000_000n,
+      });
+      expect(result.network).toBe('TESTNET');
+    });
+
+    it('rejects a memo longer than 28 characters', () => {
+      const result = CreateEscrowSchema.safeParse({
+        sender: ADDR_A,
+        recipient: ADDR_B,
+        amount: 1_000_000n,
+        memo: 'x'.repeat(29),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an invalid sender address', () => {
+      const result = CreateEscrowSchema.safeParse({
+        sender: 'not-an-address',
+        recipient: ADDR_B,
+        amount: 1_000_000n,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ReleaseEscrowSchema', () => {
+    it('parses valid input', () => {
+      const result = ReleaseEscrowSchema.safeParse({ escrowId: 'escrow-1', recipient: ADDR_A });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty escrowId', () => {
+      const result = ReleaseEscrowSchema.safeParse({ escrowId: '', recipient: ADDR_A });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('DisputeEscrowSchema', () => {
+    it('rejects a reason shorter than 10 characters', () => {
+      const result = DisputeEscrowSchema.safeParse({ escrowId: 'escrow-1', reason: 'too short' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid reason and optional evidence URL', () => {
+      const result = DisputeEscrowSchema.safeParse({
+        escrowId: 'escrow-1',
+        reason: 'work was never delivered',
+        evidence: 'https://example.com/proof.png',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a malformed evidence URL', () => {
+      const result = DisputeEscrowSchema.safeParse({
+        escrowId: 'escrow-1',
+        reason: 'work was never delivered',
+        evidence: 'not-a-url',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ClientConfigSchema', () => {
+    it('parses valid config and defaults network to TESTNET', () => {
+      const result = ClientConfigSchema.parse({ contractId: CONTRACT_ID });
+      expect(result.network).toBe('TESTNET');
+    });
+
+    it('rejects an invalid rpcUrl', () => {
+      const result = ClientConfigSchema.safeParse({ contractId: CONTRACT_ID, rpcUrl: 'nope' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a missing contractId', () => {
+      const result = ClientConfigSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
src/schemas.ts already defined the SDK's internal Zod schemas but was never wired into the public barrel, so frontend consumers couldn't reuse them. Re-export the schema objects and their non-colliding inferred *Input types from src/index.ts by name (not `export *`, since the schemas' Network/ClientConfig type aliases would otherwise ambiguously collide with the existing plain TS types of the same name in src/types.ts). Adds JSDoc/TypeDoc comments per-schema, a Jest suite covering each schema's accept/reject cases, and docs/CHANGELOG updates.

Verified `npm run build` emits the schemas in dist/index.js, dist/index.mjs, and dist/index.d.ts.


  On branch feat/export-zod-schemas (commit 59794c9):
  - Exported StellarAddressSchema, ContractIdSchema, StroopsSchema, NetworkSchema, CreateEscrowSchema, ReleaseEscrowSchema,
    DisputeEscrowSchema, ClientConfigSchema, and the *Input inferred types from src/index.ts.
  - Used explicit named exports rather than export * because the schemas' inferred Network/ClientConfig types collide with existing
    plain TS types of the same name in src/types.ts (would otherwise be a TS ambiguous-export error) — documented this decision in a
    code comment, the CHANGELOG, and docs/API.md.
  - Added JSDoc comments per schema in src/schemas.ts matching the repo's existing TypeDoc style.
  - Added tests/schemas.test.ts (24 tests, all passing) covering accept/reject cases for every schema.
  - Ran npm run build: tsup emits the schemas correctly in dist/index.js (CJS), dist/index.mjs (ESM), and dist/index.d.ts.
  - Full test suite: 178 passing. One pre-existing, unrelated failure in tests/xdr-payloads.test.ts (a missing custom Jest matcher
    type) — confirmed via git stash that it fails identically on main, so not something this change touched.


Closes #20
Closes #18
Closes #17
Closes #15