### PR TITLE
fix: export shadowed types/index.ts Escrow types from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export * from './types';
+// `./types` resolves to the sibling `types.ts` file (Node/TS module
+// resolution prefers an exact file match over a same-named directory), so
+// `types/index.ts` was never actually reachable through the package root —
+// its `EscrowState`/`EscrowParams`/`EscrowId` types silently shadowed by
+// nothing, just unexported. Explicit path re-exports both without collision
+// since none of its names overlap with the flat `Escrow` in types.ts (#80).
+export * from './types/index';
 export * from './types/contract';
 export * from './types/events';
 export * from './types/multisig';


### PR DESCRIPTION
## Summary

`src/index.ts` re-exported `'./types'`, which Node/TS module resolution matches against the sibling `types.ts` file — a file with an exact name match always wins over a same-named directory. That meant `src/types/index.ts` (containing `EscrowState`, `EscrowParams`, `EscrowId`, `EscrowFilter`) was never actually reachable from the package root, silently. Consumers importing `Escrow` got the flat shape from `types.ts`; the `EscrowState`/`EscrowParams` shape from `types/index.ts` was effectively dead code from the SDK's public surface — the two conflicting Escrow-shaped modules the issue describes.

**Fix:** added an explicit `export * from './types/index';` alongside the existing `export * from './types';`. No naming collisions — none of `types/index.ts`'s exports (`EscrowState`, `EscrowParams`, `EscrowId`, `EscrowFilter`, ...) overlap with `types.ts`'s `Escrow`, so both are now safely exported side by side.

Closes #80
Closes #25
Closes #69
Closes #22