### PR TITLE
fix(hooks): export React hooks via /react subpath, declare react peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ Read more in [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
 ---
 
+## ⚛️ React Hooks
+
+React hooks for wallet, balance, and transaction state are available from the `@trustflow/sdk/react` subpath, kept separate from the main entrypoint so non-React (Node/CLI) consumers aren't forced to install `react`:
+
+```ts
+import { useWallet, useBalance, useTransaction } from '@trustflow/sdk/react';
+```
+
+`react` (`^18.0.0 || ^19.0.0`) is a peer dependency, required only if you import from `/react`. Note: `useEscrow` is not yet exported here — it's implemented against an API that doesn't currently exist on `TrustFlowClient` (tracked in [#81](https://github.com/trustflow-protocol/trustflow-sdk/issues/81)).
+
+---
+
 ## 📚 Documentation
 
 - **[Quick Start Guide](./docs/QUICKSTART.md)** — Get up and running in 5 minutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,18 @@
         "globals": "^17.6.0",
         "jest": "^30.4.2",
         "prettier": "^3.8.4",
+        "react": "^18.2.0",
         "ts-jest": "^29.4.11",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5879,6 +5888,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6573,6 +6595,19 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is-18": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/hooks/index.d.ts",
+      "import": "./dist/hooks/index.mjs",
+      "require": "./dist/hooks/index.js"
     }
   },
   "files": [
@@ -35,11 +40,20 @@
     "axios-retry": "^4.5.0",
     "zod": "^3.22.0"
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.3",
     "@types/react": "^18.2.0",
+    "react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",
     "eslint": "^10.5.0",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,16 @@
-export { useEscrow } from './useEscrow';
 export { useWallet } from './useWallet';
 export { useBalance } from './useBalance';
 export { useTransaction } from './useTransaction';
+
+// `useEscrow` is intentionally NOT exported here (#81). It imports
+// `createEscrow`/`releaseEscrow` as free functions from '../escrow' that
+// don't exist there — that module only exports classes (including
+// `TrustFlowEscrowClient`, which *does* have `createEscrow`/`releaseEscrow`
+// methods, but isn't what this hook's `client: TrustFlowClient` parameter
+// accepts; `TrustFlowClient` itself exposes no escrow methods at all). This
+// was invisible until now because no build entry point ever pulled in
+// `src/hooks/`, so the mismatch never got type-checked. Re-wiring
+// `useEscrow` against the real API is a separate, non-trivial fix (which
+// class/instance the hook should actually take, or whether `TrustFlowClient`
+// should grow an `escrow` accessor) and is left for a follow-up rather than
+// guessed at here.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/hooks/index.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   splitting: false,


### PR DESCRIPTION
## What changed
Makes the 4 React hooks in `src/hooks/` actually reachable, and fixes the missing `react` dependency declaration:

- `src/hooks/index.ts` is now a second `tsup` build entry, exported at a new `/react` subpath (`@trustflow/sdk/react`) — kept separate from the main entrypoint so Node/CLI consumers importing only the core client aren't forced to install `react`.
- `react` (`^18.0.0 || ^19.0.0`) is declared as an optional `peerDependency`, plus a `devDependency` for building/linting.
- README documents the new subpath.

## Scope note — not a full close of #81
This PR does **not** claim `Closes #81`. Two parts of that issue's acceptance criteria aren't done here:

1. **`useEscrow` is not exported.** Building the hooks entry for the first time (never done before — no entrypoint pulled `src/hooks/` in, so it was never type-checked) surfaced that `useEscrow.ts` imports `createEscrow`/`releaseEscrow` as free functions from `../escrow` that don't exist there. Worse, its `client: TrustFlowClient` parameter type has no escrow methods at all — only the separate `TrustFlowEscrowClient` class does, with a different call signature. This is a real design mismatch, not a typo, and re-wiring it isn't something I want to guess at in this PR. Left as a follow-up; happy to open a dedicated issue for it if useful.
2. **No test suite added** for the 3 hooks that do work (`useWallet`, `useBalance`, `useTransaction`). The issue's acceptance criteria call for that explicitly, and it's real separate work (mocking `wallet/connect.ts` and the escrow client, adding a hook-testing library). Not done here.

## How verified
- `npm run build` — clean, all 3 working hooks type-check and bundle correctly under the new `/react` entry
- `npx eslint` on changed files — clean
- `npx jest` — 182/185 passing; the 3 failures are pre-existing on `main` (confirmed via `git stash` before making any change), unrelated to this PR

Refs #81

## Batch context
Issues in this batch: #83, #82, #81, #71 — all labeled Hard / multi-day. #82 additionally needs a change in a separate backend repo not reachable from here. None were fully closable honestly in this pass; #81 got real, verified partial progress as above. #83, #82, #71 are untouched, left open, tracked for follow-up.
